### PR TITLE
chore: migrate to Rust 2024 edition (MSRV 1.85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Each lives in its own module and is just a parser producing `ArgumentSpec`s via 
 - `NoopFormat` (in `lib.rs`) — passes text through unchanged; the minimal trait example.
 
 Regexes are compiled once and cached in a `OnceLock` (`get_python_regex` / `get_curly_regex`) —
-note this fork deliberately replaced `lazy_static` with `std::sync::OnceLock` (hence MSRV 1.70).
+note this fork deliberately replaced `lazy_static` with `std::sync::OnceLock` (stable since 1.70).
 
 ## Tests
 
@@ -101,6 +101,6 @@ exact text of `Error`/`FormatError` messages.
 
 ## Conventions
 
-- MSRV is **Rust 1.70.0** (`rust-version` in `Cargo.toml`) — do not use newer std APIs.
-- Edition 2021.
+- MSRV is **Rust 1.85.0** (`rust-version` in `Cargo.toml`), required by the 2024 edition.
+- Edition 2024.
 - Keep new functionality feature-gated and ensure it compiles/tests under `--no-default-features`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 name = "dynfmt2"
 version = "0.3.0"
 authors = ["Joel Natividad"]
-edition = "2021"
+edition = "2024"
 license = "MIT"
-rust-version = "1.70.0"
+rust-version = "1.85.0"
 readme = "README.md"
 repository = "https://github.com/dathere/dynfmt2"
 homepage = "https://github.com/dathere/dynfmt2"

--- a/tests/test_error_messages.rs
+++ b/tests/test_error_messages.rs
@@ -72,8 +72,4 @@ test_fmt!(
     "error formatting argument '42': %x",
     Error::BadData(Position::Index(42), "%x".into())
 );
-test_fmt!(
-    io_error,
-    "oops",
-    Error::Io(std::io::Error::new(std::io::ErrorKind::Other, "oops"))
-);
+test_fmt!(io_error, "oops", Error::Io(std::io::Error::other("oops")));


### PR DESCRIPTION
## Summary

Migrates the crate to the **Rust 2024 edition**.

- `Cargo.toml`: `edition = "2021"` → `"2024"`, and `rust-version` `1.70.0` → `1.85.0` (the 2024 edition's minimum supported Rust).
- The crate compiles cleanly under the new edition with **no source changes required** — `cargo fix --edition` reported nothing to migrate.
- Bumping the MSRV past 1.74 activates clippy's `io_other_error` lint (previously suppressed because `std::io::Error::other` didn't exist at the old MSRV), so `tests/test_error_messages.rs` now uses the cleaner `std::io::Error::other("oops")`.
- Updated `CLAUDE.md` to document edition 2024 / MSRV 1.85.

## Verification

CI gates pass locally:
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --tests -- -D clippy::all`
- `cargo test --all-features` and `cargo test --no-default-features`

## Note (out of scope)

`cargo clippy --no-default-features` surfaces a pre-existing `needless_lifetimes` warning on `src/formatter.rs:524` (`impl<'a, W> Serializer for &'a mut Formatter<W>`). The `'a` is genuinely required by the `json`-feature associated types but appears unused when `json` is off. This is edition-independent (it fires identically on `master`) and is not part of the CI clippy gate (which runs `--all-features`), so it's left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)