### PR TITLE
chore: silence needless_lifetimes on Serializer impl (json-off build)

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -521,6 +521,10 @@ impl<W: io::Write> serde::ser::SerializeStructVariant for SerializeStructVariant
     }
 }
 
+// `'a` is required by the `json`-feature associated types (e.g. `SerializeSeq<'a, W>`),
+// but with `json` off those become `Impossible<..>` and clippy sees `'a` as elidable.
+// Eliding it would break the `json` build, so allow the lint for the `json`-off case.
+#[allow(clippy::needless_lifetimes)]
 impl<'a, W> Serializer for &'a mut Formatter<W>
 where
     W: io::Write,


### PR DESCRIPTION
## Summary

`cargo clippy --no-default-features` emits a `needless_lifetimes` warning on `impl<'a, W> Serializer for &'a mut Formatter<W>` (`src/formatter.rs`).

The `'a` is **not** actually needless — it's required by the `json`-feature associated types (`type SerializeSeq = SerializeSeq<'a, W>`, etc.). With `json` off, those associated types become `serde::ser::Impossible<..>`, which doesn't name `'a`, so clippy only sees it as elidable in that one configuration. Eliding it would break the `json` (default) build.

Fix: a scoped `#[allow(clippy::needless_lifetimes)]` with a comment explaining the cfg interaction. It's inert in the `--all-features` build (where the lint never fired).

## Context

This was flagged as a pre-existing, out-of-scope note in #6 (the 2024-edition PR). It's edition-independent — it fires identically on `master` today. This PR cleans it up so `--no-default-features` clippy is green too.

## Verification

- `cargo clippy --no-default-features --tests -- -D clippy::all` ✅ (previously warned)
- `cargo clippy --all-features --tests -- -D clippy::all` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --all-features` and `cargo test --no-default-features` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)